### PR TITLE
썸네일 페이징 이미지 View 구현

### DIFF
--- a/iOS/AirbnbApp/AirbnbApp.xcodeproj/project.pbxproj
+++ b/iOS/AirbnbApp/AirbnbApp.xcodeproj/project.pbxproj
@@ -22,7 +22,7 @@
 		385D8BEE24728ECC009E2E2B /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 385D8BED24728ECC009E2E2B /* Assets.xcassets */; };
 		385D8BF124728ECC009E2E2B /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 385D8BEF24728ECC009E2E2B /* LaunchScreen.storyboard */; };
 		385D8BFC24728ECC009E2E2B /* AirbnbAppTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 385D8BFB24728ECC009E2E2B /* AirbnbAppTests.swift */; };
-		38965CB82477966C0065FCE6 /* ThumbScrollViewDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38965CB72477966C0065FCE6 /* ThumbScrollViewDelegate.swift */; };
+		38863E252478F6AB00D8C75C /* ThumbImagePagingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38863E242478F6AB00D8C75C /* ThumbImagePagingView.swift */; };
 		38BDDCAC24751DED000ACA1C /* ReviewLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38BDDCAB24751DED000ACA1C /* ReviewLabel.swift */; };
 		38BDDCAE2475A36D000ACA1C /* NSMutableAttributedString+append.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38BDDCAD2475A36D000ACA1C /* NSMutableAttributedString+append.swift */; };
 		38BDDCB02475AB21000ACA1C /* LabelWithLeadingImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38BDDCAF2475AB21000ACA1C /* LabelWithLeadingImage.swift */; };
@@ -69,7 +69,7 @@
 		385D8BF724728ECC009E2E2B /* AirbnbAppTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AirbnbAppTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		385D8BFB24728ECC009E2E2B /* AirbnbAppTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AirbnbAppTests.swift; sourceTree = "<group>"; };
 		385D8BFD24728ECC009E2E2B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		38965CB72477966C0065FCE6 /* ThumbScrollViewDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThumbScrollViewDelegate.swift; sourceTree = "<group>"; };
+		38863E242478F6AB00D8C75C /* ThumbImagePagingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThumbImagePagingView.swift; sourceTree = "<group>"; };
 		38BDDCAB24751DED000ACA1C /* ReviewLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewLabel.swift; sourceTree = "<group>"; };
 		38BDDCAD2475A36D000ACA1C /* NSMutableAttributedString+append.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSMutableAttributedString+append.swift"; sourceTree = "<group>"; };
 		38BDDCAF2475AB21000ACA1C /* LabelWithLeadingImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabelWithLeadingImage.swift; sourceTree = "<group>"; };
@@ -166,6 +166,7 @@
 				384BB7B92477D3CC0019000B /* SearchFilter */,
 				384BB7BA2477D3F90019000B /* MapButton */,
 				384BB7B72477D39C0019000B /* StayCell */,
+				38863E262478F91C00D8C75C /* ThumbImagePaging */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -220,12 +221,19 @@
 			path = AirbnbAppTests;
 			sourceTree = "<group>";
 		};
+		38863E262478F91C00D8C75C /* ThumbImagePaging */ = {
+			isa = PBXGroup;
+			children = (
+				38863E242478F6AB00D8C75C /* ThumbImagePagingView.swift */,
+			);
+			path = ThumbImagePaging;
+			sourceTree = "<group>";
+		};
 		8D32844624764B4C0078678A /* Controllers */ = {
 			isa = PBXGroup;
 			children = (
 				8D8FE71D2473CF71008FF0AF /* StayListViewController.swift */,
 				8D32844424764B0F0078678A /* SearchTextFieldDelegate.swift */,
-				38965CB72477966C0065FCE6 /* ThumbScrollViewDelegate.swift */,
 			);
 			path = Controllers;
 			sourceTree = "<group>";
@@ -361,7 +369,6 @@
 				384C0E372473E0650051528B /* StayListCollectionView.swift in Sources */,
 				8D32844524764B0F0078678A /* SearchTextFieldDelegate.swift in Sources */,
 				8DCA197324754D5A00B3C167 /* SearchFilterView.swift in Sources */,
-				38965CB82477966C0065FCE6 /* ThumbScrollViewDelegate.swift in Sources */,
 				8DCA19752475546C00B3C167 /* FilterButton.swift in Sources */,
 				8D328443247647900078678A /* ViewFromXib.swift in Sources */,
 				385D8BE724728EC8009E2E2B /* SceneDelegate.swift in Sources */,
@@ -371,6 +378,7 @@
 				381A0304247623F3004EDE84 /* PlaceTypeAndCityLabel.swift in Sources */,
 				38BDDCB02475AB21000ACA1C /* LabelWithLeadingImage.swift in Sources */,
 				381A030624762561004EDE84 /* PriceLabel.swift in Sources */,
+				38863E252478F6AB00D8C75C /* ThumbImagePagingView.swift in Sources */,
 				8D63C75D2476CFA10074BF0F /* MapButtonView.swift in Sources */,
 				38BDDCAC24751DED000ACA1C /* ReviewLabel.swift in Sources */,
 				8D8FE71E2473CF71008FF0AF /* StayListViewController.swift in Sources */,

--- a/iOS/AirbnbApp/AirbnbApp.xcodeproj/project.pbxproj
+++ b/iOS/AirbnbApp/AirbnbApp.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		384C0E3C2473F62A0051528B /* StayCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 384C0E3A2473F62A0051528B /* StayCell.swift */; };
 		384C0E3D2473F62A0051528B /* StayCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 384C0E3B2473F62A0051528B /* StayCell.xib */; };
 		384C0E4024742B7D0051528B /* StayListCollectionViewDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 384C0E3F24742B7D0051528B /* StayListCollectionViewDataSource.swift */; };
+		3859747F2478FF98004A358C /* ThumbImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3859747E2478FF98004A358C /* ThumbImageView.swift */; };
 		385D8BE524728EC8009E2E2B /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 385D8BE424728EC8009E2E2B /* AppDelegate.swift */; };
 		385D8BE724728EC8009E2E2B /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 385D8BE624728EC8009E2E2B /* SceneDelegate.swift */; };
 		385D8BE924728EC8009E2E2B /* TabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 385D8BE824728EC8009E2E2B /* TabBarController.swift */; };
@@ -59,6 +60,7 @@
 		384C0E3A2473F62A0051528B /* StayCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StayCell.swift; sourceTree = "<group>"; };
 		384C0E3B2473F62A0051528B /* StayCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = StayCell.xib; sourceTree = "<group>"; };
 		384C0E3F24742B7D0051528B /* StayListCollectionViewDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StayListCollectionViewDataSource.swift; sourceTree = "<group>"; };
+		3859747E2478FF98004A358C /* ThumbImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThumbImageView.swift; sourceTree = "<group>"; };
 		385D8BE124728EC8009E2E2B /* AirbnbApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = AirbnbApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		385D8BE424728EC8009E2E2B /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		385D8BE624728EC8009E2E2B /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -225,6 +227,7 @@
 			isa = PBXGroup;
 			children = (
 				38863E242478F6AB00D8C75C /* ThumbImagePagingView.swift */,
+				3859747E2478FF98004A358C /* ThumbImageView.swift */,
 			);
 			path = ThumbImagePaging;
 			sourceTree = "<group>";
@@ -381,6 +384,7 @@
 				38863E252478F6AB00D8C75C /* ThumbImagePagingView.swift in Sources */,
 				8D63C75D2476CFA10074BF0F /* MapButtonView.swift in Sources */,
 				38BDDCAC24751DED000ACA1C /* ReviewLabel.swift in Sources */,
+				3859747F2478FF98004A358C /* ThumbImageView.swift in Sources */,
 				8D8FE71E2473CF71008FF0AF /* StayListViewController.swift in Sources */,
 				8DCA196D24750CB900B3C167 /* SearchFieldView.swift in Sources */,
 			);

--- a/iOS/AirbnbApp/AirbnbApp/Assets.xcassets/thumb.image.background.colorset/Contents.json
+++ b/iOS/AirbnbApp/AirbnbApp/Assets.xcassets/thumb.image.background.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  },
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0.866",
+          "alpha" : "1.000",
+          "blue" : "0.866",
+          "green" : "0.866"
+        }
+      }
+    }
+  ]
+}

--- a/iOS/AirbnbApp/AirbnbApp/StayList/Controllers/ThumbScrollViewDelegate.swift
+++ b/iOS/AirbnbApp/AirbnbApp/StayList/Controllers/ThumbScrollViewDelegate.swift
@@ -1,7 +1,0 @@
-import UIKit
-
-class ThumbScrollViewDelegate: NSObject, UIScrollViewDelegate {
-    func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        let pageIndex = Int(scrollView.contentOffset.x / scrollView.frame.width)
-    }
-}

--- a/iOS/AirbnbApp/AirbnbApp/StayList/Views/StayCell/StayCell.swift
+++ b/iOS/AirbnbApp/AirbnbApp/StayList/Views/StayCell/StayCell.swift
@@ -5,10 +5,7 @@ class StayCell: UICollectionViewCell {
     static let nibName: String = String(describing: StayCell.self)
     static let reuseIdentifier: String = "StayCell"
 
-    @IBOutlet weak var scrollView: UIScrollView!
-    private var thumbScrollViewDelegate: ThumbScrollViewDelegate!
-    @IBOutlet weak var thumbImageStackView: UIStackView!
-    @IBOutlet weak var pageControl: UIPageControl!
+    @IBOutlet weak var thumbImagePagingView: ThumbImagePagingView!
     @IBOutlet weak var saveButton: UIButton!
     @IBOutlet weak var reviewLabel: ReviewLabel!
     @IBOutlet weak var superHostLabel: SuperHostLabel!
@@ -23,24 +20,10 @@ class StayCell: UICollectionViewCell {
         placeTypeAndCityLabel.updateWith(type: "Entire Apartment", city: "Upper East Side")
         titleLabel.text = "Modern luxury studio in Gangnam! 5sec to Station"
         priceLabel.updateWith(price: 1890)
-        
-        configureScrollViewDelegate()
-    }
-    
-    private func configureScrollViewDelegate() {
-        thumbScrollViewDelegate = ThumbScrollViewDelegate()
-        scrollView.delegate = thumbScrollViewDelegate
+        thumbImagePagingView.configureStackView(numberOfImage: 7)
     }
     
     @IBAction func saveButtonTapped(_ sender: Any) {
         #warning("Save Stay Action 구현")
-    }
-    
-    private func configureControlPage(numberOfPage: Int) {
-        pageControl.numberOfPages = numberOfPage
-    }
-    
-    func updateThumbnailImage(with index: Int) {
-        pageControl.currentPage = index
     }
 }

--- a/iOS/AirbnbApp/AirbnbApp/StayList/Views/StayCell/StayCell.xib
+++ b/iOS/AirbnbApp/AirbnbApp/StayList/Views/StayCell/StayCell.xib
@@ -15,20 +15,26 @@
                 <rect key="frame" x="0.0" y="0.0" width="414" height="362"/>
                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                 <subviews>
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Jms-4T-OYY" customClass="ThumbImagePagingView" customModule="AirbnbApp" customModuleProvider="target">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="248.5"/>
+                        <constraints>
+                            <constraint firstAttribute="width" secondItem="Jms-4T-OYY" secondAttribute="height" multiplier="5:3" id="ozQ-dn-hx5"/>
+                        </constraints>
+                    </view>
                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" alignment="top" spacing="2" translatesAutoresizingMaskIntoConstraints="NO" id="WGr-q7-Mzh">
-                        <rect key="frame" x="0.0" y="260.5" width="414" height="101.5"/>
+                        <rect key="frame" x="0.0" y="256.5" width="414" height="105.5"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="9VX-qu-s24">
-                                <rect key="frame" x="0.0" y="0.0" width="164.5" height="23.5"/>
+                                <rect key="frame" x="0.0" y="0.0" width="164.5" height="24.5"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="4.78 (200)" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.69999999999999996" translatesAutoresizingMaskIntoConstraints="NO" id="OdB-ur-I6Z" customClass="ReviewLabel" customModule="AirbnbApp" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="0.0" width="81.5" height="23.5"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="81.5" height="24.5"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Superhost" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.69999999999999996" translatesAutoresizingMaskIntoConstraints="NO" id="cxp-sp-qP7" customClass="SuperHostLabel" customModule="AirbnbApp" customModuleProvider="target">
-                                        <rect key="frame" x="85.5" y="0.0" width="79" height="23.5"/>
+                                        <rect key="frame" x="85.5" y="0.0" width="79" height="24.5"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
@@ -36,19 +42,19 @@
                                 </subviews>
                             </stackView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Entire Apartment ・ Upper East Side" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.59999999999999998" translatesAutoresizingMaskIntoConstraints="NO" id="264-Ef-QMx" customClass="PlaceTypeAndCityLabel" customModule="AirbnbApp" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="25.5" width="275" height="23.5"/>
+                                <rect key="frame" x="0.0" y="26.5" width="275" height="24.5"/>
                                 <fontDescription key="fontDescription" type="system" weight="light" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Modern luxury studio in Gangnam! 5sec to Station" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="VMW-cF-5mI">
-                                <rect key="frame" x="0.0" y="51" width="375.5" height="24"/>
+                                <rect key="frame" x="0.0" y="53" width="375.5" height="24.5"/>
                                 <fontDescription key="fontDescription" type="system" weight="light" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="₩99,323 / night" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="14" translatesAutoresizingMaskIntoConstraints="NO" id="K8n-Oh-f1s" customClass="PriceLabel" customModule="AirbnbApp" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="77" width="165.5" height="24.5"/>
+                                <rect key="frame" x="0.0" y="79.5" width="165.5" height="26"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
@@ -59,35 +65,6 @@
                             <constraint firstItem="264-Ef-QMx" firstAttribute="width" relation="lessThanOrEqual" secondItem="WGr-q7-Mzh" secondAttribute="width" multiplier="0.8" id="JFE-BW-Z5D"/>
                         </constraints>
                     </stackView>
-                    <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" pagingEnabled="YES" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" translatesAutoresizingMaskIntoConstraints="NO" id="o5R-JP-WcA">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="248.5"/>
-                        <subviews>
-                            <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="YOz-NC-oJL">
-                                <rect key="frame" x="0.0" y="0.0" width="0.0" height="248.5"/>
-                                <subviews>
-                                    <label hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="j0k-At-5MP">
-                                        <rect key="frame" x="0.0" y="0.0" width="0.0" height="20.5"/>
-                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                        <nil key="textColor"/>
-                                        <nil key="highlightedColor"/>
-                                    </label>
-                                </subviews>
-                            </stackView>
-                        </subviews>
-                        <constraints>
-                            <constraint firstItem="YOz-NC-oJL" firstAttribute="bottom" secondItem="MKD-Sp-NGi" secondAttribute="bottom" id="BRM-nz-L5N"/>
-                            <constraint firstItem="YOz-NC-oJL" firstAttribute="height" secondItem="dNK-yT-uQZ" secondAttribute="height" id="Btu-5Z-Egw"/>
-                            <constraint firstItem="YOz-NC-oJL" firstAttribute="trailing" secondItem="MKD-Sp-NGi" secondAttribute="trailing" id="MST-pU-w1u"/>
-                            <constraint firstItem="YOz-NC-oJL" firstAttribute="leading" secondItem="MKD-Sp-NGi" secondAttribute="leading" id="QUL-FF-D74"/>
-                            <constraint firstAttribute="width" secondItem="o5R-JP-WcA" secondAttribute="height" multiplier="5:3" id="ZBO-ed-UFC"/>
-                            <constraint firstItem="YOz-NC-oJL" firstAttribute="top" secondItem="MKD-Sp-NGi" secondAttribute="top" id="eyT-gs-Vnx"/>
-                        </constraints>
-                        <viewLayoutGuide key="contentLayoutGuide" id="MKD-Sp-NGi"/>
-                        <viewLayoutGuide key="frameLayoutGuide" id="dNK-yT-uQZ"/>
-                    </scrollView>
-                    <pageControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" defersCurrentPageDisplay="YES" numberOfPages="3" translatesAutoresizingMaskIntoConstraints="NO" id="7OR-TE-P7o">
-                        <rect key="frame" x="187.5" y="211.5" width="39" height="37"/>
-                    </pageControl>
                     <button opaque="NO" contentMode="scaleAspectFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="l2N-sy-TGs">
                         <rect key="frame" x="382" y="8" width="24" height="24"/>
                         <constraints>
@@ -105,26 +82,22 @@
             <constraints>
                 <constraint firstAttribute="trailing" secondItem="WGr-q7-Mzh" secondAttribute="trailing" id="1th-8B-jkA"/>
                 <constraint firstAttribute="trailing" secondItem="l2N-sy-TGs" secondAttribute="trailing" constant="8" id="2eg-xd-nun"/>
-                <constraint firstItem="WGr-q7-Mzh" firstAttribute="top" secondItem="o5R-JP-WcA" secondAttribute="bottom" constant="12" id="7aP-GQ-AlL"/>
                 <constraint firstItem="WGr-q7-Mzh" firstAttribute="leading" secondItem="gTV-IL-0wX" secondAttribute="leading" id="8Gf-3P-JBq"/>
                 <constraint firstItem="l2N-sy-TGs" firstAttribute="top" secondItem="gTV-IL-0wX" secondAttribute="top" constant="8" id="91U-QR-q8T"/>
-                <constraint firstItem="7OR-TE-P7o" firstAttribute="centerX" secondItem="o5R-JP-WcA" secondAttribute="centerX" id="Aay-C3-oHl"/>
-                <constraint firstItem="o5R-JP-WcA" firstAttribute="top" secondItem="gTV-IL-0wX" secondAttribute="top" id="M6h-WT-lea"/>
-                <constraint firstItem="7OR-TE-P7o" firstAttribute="bottom" secondItem="o5R-JP-WcA" secondAttribute="bottom" id="XjZ-aW-9r7"/>
-                <constraint firstItem="o5R-JP-WcA" firstAttribute="leading" secondItem="gTV-IL-0wX" secondAttribute="leading" id="XoW-QX-mFE"/>
+                <constraint firstAttribute="trailing" secondItem="Jms-4T-OYY" secondAttribute="trailing" id="TsZ-ej-J0U"/>
+                <constraint firstItem="WGr-q7-Mzh" firstAttribute="top" secondItem="Jms-4T-OYY" secondAttribute="bottom" constant="8" symbolic="YES" id="Ug3-NH-JF0"/>
+                <constraint firstItem="Jms-4T-OYY" firstAttribute="leading" secondItem="gTV-IL-0wX" secondAttribute="leading" id="hf3-zD-qpZ"/>
                 <constraint firstAttribute="bottom" secondItem="WGr-q7-Mzh" secondAttribute="bottom" id="hlK-7s-6OC"/>
-                <constraint firstAttribute="trailing" secondItem="o5R-JP-WcA" secondAttribute="trailing" id="s0h-ZM-hWa"/>
+                <constraint firstItem="Jms-4T-OYY" firstAttribute="top" secondItem="gTV-IL-0wX" secondAttribute="top" id="vmJ-Ze-ooW"/>
             </constraints>
             <size key="customSize" width="370" height="362"/>
             <connections>
-                <outlet property="pageControl" destination="7OR-TE-P7o" id="LLN-sH-vRw"/>
                 <outlet property="placeTypeAndCityLabel" destination="264-Ef-QMx" id="ndC-Kn-Yff"/>
                 <outlet property="priceLabel" destination="K8n-Oh-f1s" id="igF-YW-kMJ"/>
                 <outlet property="reviewLabel" destination="OdB-ur-I6Z" id="CaZ-VQ-A4o"/>
                 <outlet property="saveButton" destination="l2N-sy-TGs" id="rAu-2a-W4w"/>
-                <outlet property="scrollView" destination="o5R-JP-WcA" id="cNb-Z1-1MH"/>
                 <outlet property="superHostLabel" destination="cxp-sp-qP7" id="FCy-xi-PCK"/>
-                <outlet property="thumbImageStackView" destination="YOz-NC-oJL" id="oTG-bR-aOL"/>
+                <outlet property="thumbImagePagingView" destination="Jms-4T-OYY" id="vqA-5C-TFe"/>
                 <outlet property="titleLabel" destination="VMW-cF-5mI" id="Nn4-A5-zWU"/>
             </connections>
             <point key="canvasLocation" x="168.11594202898553" y="256.47321428571428"/>

--- a/iOS/AirbnbApp/AirbnbApp/StayList/Views/ThumbImagePaging/ThumbImagePagingView.swift
+++ b/iOS/AirbnbApp/AirbnbApp/StayList/Views/ThumbImagePaging/ThumbImagePagingView.swift
@@ -1,0 +1,85 @@
+import UIKit
+
+final class ThumbImagePagingView: UIView {
+
+    private var scrollView: UIScrollView!
+    private var pageControl: UIPageControl!
+    private var imageStackView: UIStackView!
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configure()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        configure()
+    }
+    
+    func configureStackView(numberOfImage: Int) {
+        pageControl.numberOfPages = numberOfImage
+        
+        for _ in 0..<numberOfImage {
+            let imageView = UIImageView()
+            imageView.backgroundColor = UIColor(named: "thumb.image.background")
+            imageStackView.addArrangedSubview(imageView)
+            imageView.translatesAutoresizingMaskIntoConstraints = false
+            imageView.widthAnchor.constraint(equalTo: scrollView.frameLayoutGuide.widthAnchor).isActive = true
+            imageView.layer.cornerRadius = 12
+            imageView.contentMode = .scaleAspectFit
+            imageView.clipsToBounds = true
+        }
+    }
+    
+    private func configure() {
+        configureUI()
+        configureScrollViewDelegate()
+        configureLayout()
+    }
+    
+    private func configureUI() {
+        scrollView = UIScrollView()
+        scrollView.isPagingEnabled = true
+        scrollView.showsHorizontalScrollIndicator = false
+        pageControl = UIPageControl()
+        pageControl.defersCurrentPageDisplay = true
+        imageStackView = UIStackView()
+    }
+    
+    private func configureScrollViewDelegate() {
+        scrollView.delegate = self
+    }
+    
+    private func updatePageControl(to index: Int) {
+        guard pageControl.currentPage != index else { return }
+        pageControl.currentPage = index
+    }
+}
+
+// MARK:- ScrollViewDelegate
+extension ThumbImagePagingView: UIScrollViewDelegate {
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        let pageIndex = Int(scrollView.contentOffset.x / scrollView.bounds.width)
+        updatePageControl(to: pageIndex)
+    }
+}
+
+// MARK:- Layout Configuration
+extension ThumbImagePagingView {
+    private func configureLayout() {
+        addSubviews(scrollView,
+                    pageControl)
+        scrollView.addSubview(imageStackView)
+        
+        scrollView.fillSuperview()
+        pageControl.translatesAutoresizingMaskIntoConstraints = false
+        pageControl.centerXAnchor.constraint(equalTo: centerXAnchor).isActive = true
+        pageControl.bottomAnchor.constraint(equalTo: bottomAnchor).isActive = true
+
+        imageStackView.constraints(topAnchor: scrollView.contentLayoutGuide.topAnchor,
+                                   leadingAnchor: scrollView.contentLayoutGuide.leadingAnchor,
+                                   bottomAnchor: scrollView.contentLayoutGuide.bottomAnchor,
+                                   trailingAnchor: scrollView.contentLayoutGuide.trailingAnchor)
+        imageStackView.heightAnchor.constraint(equalTo: scrollView.frameLayoutGuide.heightAnchor).isActive = true
+    }
+}

--- a/iOS/AirbnbApp/AirbnbApp/StayList/Views/ThumbImagePaging/ThumbImagePagingView.swift
+++ b/iOS/AirbnbApp/AirbnbApp/StayList/Views/ThumbImagePaging/ThumbImagePagingView.swift
@@ -20,14 +20,9 @@ final class ThumbImagePagingView: UIView {
         pageControl.numberOfPages = numberOfImage
         
         for _ in 0..<numberOfImage {
-            let imageView = UIImageView()
-            imageView.backgroundColor = UIColor(named: "thumb.image.background")
+            let imageView = ThumbImageView()
             imageStackView.addArrangedSubview(imageView)
-            imageView.translatesAutoresizingMaskIntoConstraints = false
             imageView.widthAnchor.constraint(equalTo: scrollView.frameLayoutGuide.widthAnchor).isActive = true
-            imageView.layer.cornerRadius = 12
-            imageView.contentMode = .scaleAspectFit
-            imageView.clipsToBounds = true
         }
     }
     

--- a/iOS/AirbnbApp/AirbnbApp/StayList/Views/ThumbImagePaging/ThumbImageView.swift
+++ b/iOS/AirbnbApp/AirbnbApp/StayList/Views/ThumbImagePaging/ThumbImageView.swift
@@ -1,0 +1,32 @@
+import UIKit
+
+final class ThumbImageView: UIImageView {
+    
+    private let cornerRadius: CGFloat = 12
+    
+    override init(frame: CGRect = .zero) {
+        super.init(frame: frame)
+        configure()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        configure()
+    }
+    
+    private func configure() {
+        configureUI()
+        configureLayer()
+    }
+    
+    private func configureUI() {
+        backgroundColor = UIColor(named: "thumb.image.background")
+        translatesAutoresizingMaskIntoConstraints = false
+        contentMode = .scaleAspectFit
+        clipsToBounds = true
+    }
+    
+    private func configureLayer() {
+        layer.cornerRadius = cornerRadius
+    }
+}


### PR DESCRIPTION
## StayCell XIB 구현에서 분리

StayCell은 XIB로 구현되어있는데, scrollView, stackView를 empty 상태로 XIB에서 구현을 하면 까다롭기 때문에, 코드로 작업해주기 위해서 기존 scrollView의 Layout을 대체할 UIView를 하나 넣어두었습니다.
이 View는 ThumbImagePagingView로 해당 뷰 내부에서 코드로 scrollView, stackView를 추가하여 처리하였습니다.

## ScrollViewDelegate

기존에 scrollViewDelegate를 ThumbImageScrollViewDelegate 클래스로 분리해서 구현했습니다. 하지만 분리하는 의미가 크게 없다고 생각하여 ThumbImagePagingView가 UIScrollViewDelegate를 채택하여 구현하였습니다.

## ThumbImageView

이미지 뷰를 먼저 stackView에서 세팅을 해주는데, 이미지 뷰마다 설정해줘야할 프로퍼티들이 있어 커스텀 클래스로 구현하였습니다.