### PR TITLE
StayDetailView 기본 동작 구현

### DIFF
--- a/iOS/AirbnbApp/AirbnbApp.xcodeproj/project.pbxproj
+++ b/iOS/AirbnbApp/AirbnbApp.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 51;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -38,6 +38,8 @@
 		8D63C75B2476CF4E0074BF0F /* MapButtonView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 8D63C75A2476CF4E0074BF0F /* MapButtonView.xib */; };
 		8D63C75D2476CFA10074BF0F /* MapButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D63C75C2476CFA10074BF0F /* MapButtonView.swift */; };
 		8D8FE71E2473CF71008FF0AF /* StayListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D8FE71D2473CF71008FF0AF /* StayListViewController.swift */; };
+		8D9B7A10247C06E500D9A99D /* StayDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D9B7A0E247C06E500D9A99D /* StayDetailViewController.swift */; };
+		8D9B7A11247C06E500D9A99D /* StayDetailViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 8D9B7A0F247C06E500D9A99D /* StayDetailViewController.xib */; };
 		8DCA196D24750CB900B3C167 /* SearchFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DCA196C24750CB900B3C167 /* SearchFieldView.swift */; };
 		8DCA196F24750CCF00B3C167 /* SearchFieldView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 8DCA196E24750CCF00B3C167 /* SearchFieldView.xib */; };
 		8DCA197124754B7900B3C167 /* SearchFilterView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 8DCA197024754B7900B3C167 /* SearchFilterView.xib */; };
@@ -94,6 +96,8 @@
 		8D63C75A2476CF4E0074BF0F /* MapButtonView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = MapButtonView.xib; sourceTree = "<group>"; };
 		8D63C75C2476CFA10074BF0F /* MapButtonView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MapButtonView.swift; sourceTree = "<group>"; };
 		8D8FE71D2473CF71008FF0AF /* StayListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StayListViewController.swift; sourceTree = "<group>"; };
+		8D9B7A0E247C06E500D9A99D /* StayDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StayDetailViewController.swift; sourceTree = "<group>"; };
+		8D9B7A0F247C06E500D9A99D /* StayDetailViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = StayDetailViewController.xib; sourceTree = "<group>"; };
 		8DCA196C24750CB900B3C167 /* SearchFieldView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchFieldView.swift; sourceTree = "<group>"; };
 		8DCA196E24750CCF00B3C167 /* SearchFieldView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SearchFieldView.xib; sourceTree = "<group>"; };
 		8DCA197024754B7900B3C167 /* SearchFilterView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SearchFilterView.xib; sourceTree = "<group>"; };
@@ -132,7 +136,6 @@
 				51291177216A70DD7B1C174C /* Pods-AirbnbAppTests.debug.xcconfig */,
 				F0B4FABD941046CDEC24AF71 /* Pods-AirbnbAppTests.release.xcconfig */,
 			);
-			name = Pods;
 			path = Pods;
 			sourceTree = "<group>";
 		};
@@ -238,6 +241,7 @@
 			children = (
 				8D8FE71B2473CF23008FF0AF /* TabBar */,
 				8D8FE71C2473CF3C008FF0AF /* StayList */,
+				8D9B7A0D247C066300D9A99D /* StayDetail */,
 				384C0E322473D9380051528B /* Extensions */,
 				385D8BE424728EC8009E2E2B /* AppDelegate.swift */,
 				385D8BE624728EC8009E2E2B /* SceneDelegate.swift */,
@@ -301,6 +305,15 @@
 				384C0E352473E04C0051528B /* Views */,
 			);
 			path = StayList;
+			sourceTree = "<group>";
+		};
+		8D9B7A0D247C066300D9A99D /* StayDetail */ = {
+			isa = PBXGroup;
+			children = (
+				8D9B7A0E247C06E500D9A99D /* StayDetailViewController.swift */,
+				8D9B7A0F247C06E500D9A99D /* StayDetailViewController.xib */,
+			);
+			path = StayDetail;
 			sourceTree = "<group>";
 		};
 		BB525B3078B278E3107AD411 /* Frameworks */ = {
@@ -400,6 +413,7 @@
 				385D8BF124728ECC009E2E2B /* LaunchScreen.storyboard in Resources */,
 				8DCA196F24750CCF00B3C167 /* SearchFieldView.xib in Resources */,
 				385D8BEE24728ECC009E2E2B /* Assets.xcassets in Resources */,
+				8D9B7A11247C06E500D9A99D /* StayDetailViewController.xib in Resources */,
 				384C0E3D2473F62A0051528B /* StayCell.xib in Resources */,
 				8DCA197124754B7900B3C167 /* SearchFilterView.xib in Resources */,
 			);
@@ -495,6 +509,7 @@
 				8DCA19752475546C00B3C167 /* FilterButton.swift in Sources */,
 				8D328443247647900078678A /* ViewFromXib.swift in Sources */,
 				385D8BE724728EC8009E2E2B /* SceneDelegate.swift in Sources */,
+				8D9B7A10247C06E500D9A99D /* StayDetailViewController.swift in Sources */,
 				38BDDCAE2475A36D000ACA1C /* NSMutableAttributedString+append.swift in Sources */,
 				384C0E392473F50F0051528B /* UIView+addSubviews.swift in Sources */,
 				38BDDCB22475AD43000ACA1C /* SuperHostLabel.swift in Sources */,

--- a/iOS/AirbnbApp/AirbnbApp.xcodeproj/project.pbxproj
+++ b/iOS/AirbnbApp/AirbnbApp.xcodeproj/project.pbxproj
@@ -9,7 +9,7 @@
 /* Begin PBXBuildFile section */
 		381A0304247623F3004EDE84 /* PlaceTypeAndCityLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 381A0303247623F3004EDE84 /* PlaceTypeAndCityLabel.swift */; };
 		381A030624762561004EDE84 /* PriceLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 381A030524762561004EDE84 /* PriceLabel.swift */; };
-		3839C7B02477D6760039BB19 /* SeperatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3839C7AF2477D6760039BB19 /* SeperatorView.swift */; };
+		3839C7B02477D6760039BB19 /* SeparatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3839C7AF2477D6760039BB19 /* SeparatorView.swift */; };
 		384C0E342473D9680051528B /* UIView+AutoLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 384C0E332473D9680051528B /* UIView+AutoLayout.swift */; };
 		384C0E372473E0650051528B /* StayListCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 384C0E362473E0650051528B /* StayListCollectionView.swift */; };
 		384C0E392473F50F0051528B /* UIView+addSubviews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 384C0E382473F50F0051528B /* UIView+addSubviews.swift */; };
@@ -40,6 +40,9 @@
 		8D8FE71E2473CF71008FF0AF /* StayListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D8FE71D2473CF71008FF0AF /* StayListViewController.swift */; };
 		8D9B7A10247C06E500D9A99D /* StayDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D9B7A0E247C06E500D9A99D /* StayDetailViewController.swift */; };
 		8D9B7A11247C06E500D9A99D /* StayDetailViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 8D9B7A0F247C06E500D9A99D /* StayDetailViewController.xib */; };
+		8D9B7A13247C09E500D9A99D /* DetailSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D9B7A12247C09E500D9A99D /* DetailSectionView.swift */; };
+		8D9B7A15247C09F700D9A99D /* DetailSectionView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 8D9B7A14247C09F700D9A99D /* DetailSectionView.xib */; };
+		8D9B7A17247C0F1200D9A99D /* StayListCollectionViewDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D9B7A16247C0F1200D9A99D /* StayListCollectionViewDelegate.swift */; };
 		8DCA196D24750CB900B3C167 /* SearchFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DCA196C24750CB900B3C167 /* SearchFieldView.swift */; };
 		8DCA196F24750CCF00B3C167 /* SearchFieldView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 8DCA196E24750CCF00B3C167 /* SearchFieldView.xib */; };
 		8DCA197124754B7900B3C167 /* SearchFilterView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 8DCA197024754B7900B3C167 /* SearchFilterView.xib */; };
@@ -61,7 +64,7 @@
 /* Begin PBXFileReference section */
 		381A0303247623F3004EDE84 /* PlaceTypeAndCityLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaceTypeAndCityLabel.swift; sourceTree = "<group>"; };
 		381A030524762561004EDE84 /* PriceLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PriceLabel.swift; sourceTree = "<group>"; };
-		3839C7AF2477D6760039BB19 /* SeperatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeperatorView.swift; sourceTree = "<group>"; };
+		3839C7AF2477D6760039BB19 /* SeparatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeparatorView.swift; sourceTree = "<group>"; };
 		384C0E332473D9680051528B /* UIView+AutoLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+AutoLayout.swift"; sourceTree = "<group>"; };
 		384C0E362473E0650051528B /* StayListCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StayListCollectionView.swift; sourceTree = "<group>"; };
 		384C0E382473F50F0051528B /* UIView+addSubviews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+addSubviews.swift"; sourceTree = "<group>"; };
@@ -98,6 +101,9 @@
 		8D8FE71D2473CF71008FF0AF /* StayListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StayListViewController.swift; sourceTree = "<group>"; };
 		8D9B7A0E247C06E500D9A99D /* StayDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StayDetailViewController.swift; sourceTree = "<group>"; };
 		8D9B7A0F247C06E500D9A99D /* StayDetailViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = StayDetailViewController.xib; sourceTree = "<group>"; };
+		8D9B7A12247C09E500D9A99D /* DetailSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailSectionView.swift; sourceTree = "<group>"; };
+		8D9B7A14247C09F700D9A99D /* DetailSectionView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = DetailSectionView.xib; sourceTree = "<group>"; };
+		8D9B7A16247C0F1200D9A99D /* StayListCollectionViewDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StayListCollectionViewDelegate.swift; sourceTree = "<group>"; };
 		8DCA196C24750CB900B3C167 /* SearchFieldView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchFieldView.swift; sourceTree = "<group>"; };
 		8DCA196E24750CCF00B3C167 /* SearchFieldView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SearchFieldView.xib; sourceTree = "<group>"; };
 		8DCA197024754B7900B3C167 /* SearchFilterView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SearchFilterView.xib; sourceTree = "<group>"; };
@@ -196,7 +202,7 @@
 			children = (
 				8D328442247647900078678A /* ViewFromXib.swift */,
 				384C0E362473E0650051528B /* StayListCollectionView.swift */,
-				3839C7AF2477D6760039BB19 /* SeperatorView.swift */,
+				3839C7AF2477D6760039BB19 /* SeparatorView.swift */,
 				38EB9D8E2479A48100236DB4 /* LoadingView.swift */,
 				384BB7B82477D3BC0019000B /* SearchField */,
 				384BB7B92477D3CC0019000B /* SearchFilter */,
@@ -284,6 +290,7 @@
 			children = (
 				8D8FE71D2473CF71008FF0AF /* StayListViewController.swift */,
 				8D32844424764B0F0078678A /* SearchTextFieldDelegate.swift */,
+				8D9B7A16247C0F1200D9A99D /* StayListCollectionViewDelegate.swift */,
 			);
 			path = Controllers;
 			sourceTree = "<group>";
@@ -312,6 +319,8 @@
 			children = (
 				8D9B7A0E247C06E500D9A99D /* StayDetailViewController.swift */,
 				8D9B7A0F247C06E500D9A99D /* StayDetailViewController.xib */,
+				8D9B7A12247C09E500D9A99D /* DetailSectionView.swift */,
+				8D9B7A14247C09F700D9A99D /* DetailSectionView.xib */,
 			);
 			path = StayDetail;
 			sourceTree = "<group>";
@@ -410,6 +419,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				8D63C75B2476CF4E0074BF0F /* MapButtonView.xib in Resources */,
+				8D9B7A15247C09F700D9A99D /* DetailSectionView.xib in Resources */,
 				385D8BF124728ECC009E2E2B /* LaunchScreen.storyboard in Resources */,
 				8DCA196F24750CCF00B3C167 /* SearchFieldView.xib in Resources */,
 				385D8BEE24728ECC009E2E2B /* Assets.xcassets in Resources */,
@@ -498,8 +508,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				384C0E342473D9680051528B /* UIView+AutoLayout.swift in Sources */,
+				8D9B7A17247C0F1200D9A99D /* StayListCollectionViewDelegate.swift in Sources */,
 				385D8BE924728EC8009E2E2B /* TabBarController.swift in Sources */,
-				3839C7B02477D6760039BB19 /* SeperatorView.swift in Sources */,
+				3839C7B02477D6760039BB19 /* SeparatorView.swift in Sources */,
 				384C0E3C2473F62A0051528B /* StayCell.swift in Sources */,
 				385D8BE524728EC8009E2E2B /* AppDelegate.swift in Sources */,
 				384C0E372473E0650051528B /* StayListCollectionView.swift in Sources */,
@@ -524,6 +535,7 @@
 				38EB9D8F2479A48100236DB4 /* LoadingView.swift in Sources */,
 				3859747F2478FF98004A358C /* ThumbImageView.swift in Sources */,
 				8D8FE71E2473CF71008FF0AF /* StayListViewController.swift in Sources */,
+				8D9B7A13247C09E500D9A99D /* DetailSectionView.swift in Sources */,
 				38F1F89224795E0400454668 /* Stay.swift in Sources */,
 				8DCA196D24750CB900B3C167 /* SearchFieldView.swift in Sources */,
 			);

--- a/iOS/AirbnbApp/AirbnbApp.xcodeproj/project.pbxproj
+++ b/iOS/AirbnbApp/AirbnbApp.xcodeproj/project.pbxproj
@@ -43,6 +43,8 @@
 		8D9B7A13247C09E500D9A99D /* DetailSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D9B7A12247C09E500D9A99D /* DetailSectionView.swift */; };
 		8D9B7A15247C09F700D9A99D /* DetailSectionView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 8D9B7A14247C09F700D9A99D /* DetailSectionView.xib */; };
 		8D9B7A17247C0F1200D9A99D /* StayListCollectionViewDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D9B7A16247C0F1200D9A99D /* StayListCollectionViewDelegate.swift */; };
+		8D9B7A19247C1D4500D9A99D /* DetailButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D9B7A18247C1D4500D9A99D /* DetailButton.swift */; };
+		8D9B7A1B247C206400D9A99D /* RoundedBorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D9B7A1A247C206400D9A99D /* RoundedBorder.swift */; };
 		8DCA196D24750CB900B3C167 /* SearchFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DCA196C24750CB900B3C167 /* SearchFieldView.swift */; };
 		8DCA196F24750CCF00B3C167 /* SearchFieldView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 8DCA196E24750CCF00B3C167 /* SearchFieldView.xib */; };
 		8DCA197124754B7900B3C167 /* SearchFilterView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 8DCA197024754B7900B3C167 /* SearchFilterView.xib */; };
@@ -104,6 +106,8 @@
 		8D9B7A12247C09E500D9A99D /* DetailSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailSectionView.swift; sourceTree = "<group>"; };
 		8D9B7A14247C09F700D9A99D /* DetailSectionView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = DetailSectionView.xib; sourceTree = "<group>"; };
 		8D9B7A16247C0F1200D9A99D /* StayListCollectionViewDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StayListCollectionViewDelegate.swift; sourceTree = "<group>"; };
+		8D9B7A18247C1D4500D9A99D /* DetailButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailButton.swift; sourceTree = "<group>"; };
+		8D9B7A1A247C206400D9A99D /* RoundedBorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoundedBorder.swift; sourceTree = "<group>"; };
 		8DCA196C24750CB900B3C167 /* SearchFieldView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchFieldView.swift; sourceTree = "<group>"; };
 		8DCA196E24750CCF00B3C167 /* SearchFieldView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SearchFieldView.xib; sourceTree = "<group>"; };
 		8DCA197024754B7900B3C167 /* SearchFilterView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SearchFilterView.xib; sourceTree = "<group>"; };
@@ -321,6 +325,8 @@
 				8D9B7A0F247C06E500D9A99D /* StayDetailViewController.xib */,
 				8D9B7A12247C09E500D9A99D /* DetailSectionView.swift */,
 				8D9B7A14247C09F700D9A99D /* DetailSectionView.xib */,
+				8D9B7A18247C1D4500D9A99D /* DetailButton.swift */,
+				8D9B7A1A247C206400D9A99D /* RoundedBorder.swift */,
 			);
 			path = StayDetail;
 			sourceTree = "<group>";
@@ -534,7 +540,9 @@
 				38BDDCAC24751DED000ACA1C /* ReviewLabel.swift in Sources */,
 				38EB9D8F2479A48100236DB4 /* LoadingView.swift in Sources */,
 				3859747F2478FF98004A358C /* ThumbImageView.swift in Sources */,
+				8D9B7A1B247C206400D9A99D /* RoundedBorder.swift in Sources */,
 				8D8FE71E2473CF71008FF0AF /* StayListViewController.swift in Sources */,
+				8D9B7A19247C1D4500D9A99D /* DetailButton.swift in Sources */,
 				8D9B7A13247C09E500D9A99D /* DetailSectionView.swift in Sources */,
 				38F1F89224795E0400454668 /* Stay.swift in Sources */,
 				8DCA196D24750CB900B3C167 /* SearchFieldView.swift in Sources */,

--- a/iOS/AirbnbApp/AirbnbApp.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/iOS/AirbnbApp/AirbnbApp.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/iOS/AirbnbApp/AirbnbApp/StayDetail/DetailButton.swift
+++ b/iOS/AirbnbApp/AirbnbApp/StayDetail/DetailButton.swift
@@ -1,0 +1,18 @@
+import UIKit
+
+class DetailButton: UIButton, RoundedBorder {
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        configure()
+    }
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configure()
+    }
+
+    private func configure() {
+        drawBorder()
+    }
+}

--- a/iOS/AirbnbApp/AirbnbApp/StayDetail/DetailSectionView.swift
+++ b/iOS/AirbnbApp/AirbnbApp/StayDetail/DetailSectionView.swift
@@ -1,0 +1,6 @@
+import UIKit
+
+class DetailSectionView: UIView, ViewFromXib {
+
+    static let xibName = String(describing: DetailSectionView.self)
+}

--- a/iOS/AirbnbApp/AirbnbApp/StayDetail/DetailSectionView.xib
+++ b/iOS/AirbnbApp/AirbnbApp/StayDetail/DetailSectionView.xib
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="iN0-l3-epB" customClass="DetailSectionView" customModule="AirbnbApp" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="414" height="233"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ols-dC-cVD">
+                    <rect key="frame" x="20" y="15" width="42" height="21"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                    <nil key="textColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+            </subviews>
+            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+            <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
+            <point key="canvasLocation" x="-225" y="-22"/>
+        </view>
+    </objects>
+</document>

--- a/iOS/AirbnbApp/AirbnbApp/StayDetail/DetailSectionView.xib
+++ b/iOS/AirbnbApp/AirbnbApp/StayDetail/DetailSectionView.xib
@@ -20,6 +20,11 @@
                     <nil key="textColor"/>
                     <nil key="highlightedColor"/>
                 </label>
+                <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="CcS-Ww-7aU" customClass="DetailButton" customModule="AirbnbApp" customModuleProvider="target">
+                    <rect key="frame" x="20" y="44" width="46" height="30"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                    <state key="normal" title="Button"/>
+                </button>
             </subviews>
             <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>

--- a/iOS/AirbnbApp/AirbnbApp/StayDetail/RoundedBorder.swift
+++ b/iOS/AirbnbApp/AirbnbApp/StayDetail/RoundedBorder.swift
@@ -1,0 +1,13 @@
+import UIKit
+
+protocol RoundedBorder: UIView {
+    func drawBorder(cornerRadius: CGFloat, borderWidth: CGFloat, borderColor: CGColor)
+}
+
+extension RoundedBorder {
+    func drawBorder(cornerRadius: CGFloat = 5, borderWidth: CGFloat = 1, borderColor: CGColor = UIColor.black.cgColor) {
+        layer.cornerRadius = cornerRadius
+        layer.borderWidth = borderWidth
+        layer.borderColor = borderColor
+    }
+}

--- a/iOS/AirbnbApp/AirbnbApp/StayDetail/StayDetailViewController.swift
+++ b/iOS/AirbnbApp/AirbnbApp/StayDetail/StayDetailViewController.swift
@@ -1,0 +1,12 @@
+import UIKit
+
+class StayDetailViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+    }
+
+
+    // MARK: - Navigation
+}

--- a/iOS/AirbnbApp/AirbnbApp/StayDetail/StayDetailViewController.swift
+++ b/iOS/AirbnbApp/AirbnbApp/StayDetail/StayDetailViewController.swift
@@ -10,6 +10,5 @@ class StayDetailViewController: UIViewController {
         stackView.addArrangedSubview(detailSectionView)
     }
 
-
     // MARK: - Navigation
 }

--- a/iOS/AirbnbApp/AirbnbApp/StayDetail/StayDetailViewController.swift
+++ b/iOS/AirbnbApp/AirbnbApp/StayDetail/StayDetailViewController.swift
@@ -1,12 +1,13 @@
 import UIKit
 
 class StayDetailViewController: UIViewController {
+    @IBOutlet weak var stackView: UIStackView!
 
     override func viewDidLoad() {
         super.viewDidLoad()
 
         let detailSectionView = DetailSectionView.loadFromXib()
-        view.addSubview(detailSectionView)
+        stackView.addArrangedSubview(detailSectionView)
     }
 
 

--- a/iOS/AirbnbApp/AirbnbApp/StayDetail/StayDetailViewController.swift
+++ b/iOS/AirbnbApp/AirbnbApp/StayDetail/StayDetailViewController.swift
@@ -5,6 +5,8 @@ class StayDetailViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        let detailSectionView = DetailSectionView.loadFromXib()
+        view.addSubview(detailSectionView)
     }
 
 

--- a/iOS/AirbnbApp/AirbnbApp/StayDetail/StayDetailViewController.xib
+++ b/iOS/AirbnbApp/AirbnbApp/StayDetail/StayDetailViewController.xib
@@ -9,6 +9,7 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="StayDetailViewController" customModule="AirbnbApp" customModuleProvider="target">
             <connections>
+                <outlet property="stackView" destination="nIX-aF-DtO" id="NdW-G1-dat"/>
                 <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
             </connections>
         </placeholder>

--- a/iOS/AirbnbApp/AirbnbApp/StayDetail/StayDetailViewController.xib
+++ b/iOS/AirbnbApp/AirbnbApp/StayDetail/StayDetailViewController.xib
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="StayDetailViewController" customModule="AirbnbApp" customModuleProvider="target">
+            <connections>
+                <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="i5M-Pr-FkT">
+            <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ihf-tZ-CWi">
+                    <rect key="frame" x="0.0" y="44" width="414" height="818"/>
+                    <subviews>
+                        <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="nIX-aF-DtO">
+                            <rect key="frame" x="0.0" y="0.0" width="414" height="818"/>
+                        </stackView>
+                    </subviews>
+                    <constraints>
+                        <constraint firstItem="nIX-aF-DtO" firstAttribute="trailing" secondItem="zPR-jX-7L8" secondAttribute="trailing" constant="414" id="XnL-Ha-s6T"/>
+                        <constraint firstItem="nIX-aF-DtO" firstAttribute="leading" secondItem="zPR-jX-7L8" secondAttribute="leading" id="hEM-LA-lj6"/>
+                        <constraint firstItem="nIX-aF-DtO" firstAttribute="width" secondItem="rft-re-ZP4" secondAttribute="width" id="rus-LS-ikt"/>
+                        <constraint firstItem="nIX-aF-DtO" firstAttribute="top" secondItem="zPR-jX-7L8" secondAttribute="top" id="yd3-Kh-HQR"/>
+                        <constraint firstItem="nIX-aF-DtO" firstAttribute="bottom" secondItem="zPR-jX-7L8" secondAttribute="bottom" constant="818" id="zAk-h3-MKp"/>
+                    </constraints>
+                    <viewLayoutGuide key="contentLayoutGuide" id="zPR-jX-7L8"/>
+                    <viewLayoutGuide key="frameLayoutGuide" id="rft-re-ZP4"/>
+                </scrollView>
+            </subviews>
+            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+            <constraints>
+                <constraint firstItem="ihf-tZ-CWi" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="WvB-Ka-3ac"/>
+                <constraint firstItem="ihf-tZ-CWi" firstAttribute="bottom" secondItem="fnl-2z-Ty3" secondAttribute="bottom" id="b0X-Sx-0Uy"/>
+                <constraint firstItem="ihf-tZ-CWi" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" id="jhF-wF-esS"/>
+                <constraint firstItem="ihf-tZ-CWi" firstAttribute="trailing" secondItem="i5M-Pr-FkT" secondAttribute="trailing" id="wCI-5F-YZP"/>
+            </constraints>
+            <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
+            <point key="canvasLocation" x="137.68115942028987" y="153.34821428571428"/>
+        </view>
+    </objects>
+</document>

--- a/iOS/AirbnbApp/AirbnbApp/StayList/Controllers/StayListCollectionViewDelegate.swift
+++ b/iOS/AirbnbApp/AirbnbApp/StayList/Controllers/StayListCollectionViewDelegate.swift
@@ -11,3 +11,17 @@ class StayListCollectionViewDelegate: NSObject, UICollectionViewDelegate {
         handlerWhenSelected()
     }
 }
+
+extension StayListCollectionViewDelegate: UICollectionViewDelegateFlowLayout {
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        let scrollViewHeight = collectionView.bounds.width * (3 / 5)
+        let verticalSpace: CGFloat = 12.0
+        let stackViewHeight: CGFloat = 100.0
+
+        return CGSize(width: collectionView.bounds.width, height: scrollViewHeight + verticalSpace + stackViewHeight)
+    }
+
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
+        24
+    }
+}

--- a/iOS/AirbnbApp/AirbnbApp/StayList/Controllers/StayListCollectionViewDelegate.swift
+++ b/iOS/AirbnbApp/AirbnbApp/StayList/Controllers/StayListCollectionViewDelegate.swift
@@ -1,0 +1,13 @@
+import UIKit
+
+class StayListCollectionViewDelegate: NSObject, UICollectionViewDelegate {
+    var handlerWhenSelected: () -> Void
+
+    init(handlerWhenSelected: @escaping () -> Void = {}) {
+        self.handlerWhenSelected = handlerWhenSelected
+    }
+
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        handlerWhenSelected()
+    }
+}

--- a/iOS/AirbnbApp/AirbnbApp/StayList/Controllers/StayListViewController.swift
+++ b/iOS/AirbnbApp/AirbnbApp/StayList/Controllers/StayListViewController.swift
@@ -65,8 +65,6 @@ class StayListViewController: UIViewController {
     
     private func configureCollectionView() {
         stayListCollectionView.dataSource = stayListCollectionViewDataSource
-
-        // FIXME: delegate 지정하면 셀 크기가 이상하게 바뀜
         stayListCollectionView.delegate = stayListCollectionViewDelegate
     }
     

--- a/iOS/AirbnbApp/AirbnbApp/StayList/Controllers/StayListViewController.swift
+++ b/iOS/AirbnbApp/AirbnbApp/StayList/Controllers/StayListViewController.swift
@@ -50,7 +50,7 @@ class StayListViewController: UIViewController {
 
         stayListCollectionViewDelegate = StayListCollectionViewDelegate(handlerWhenSelected: { [weak self] in
             let detailViewController = StayDetailViewController()
-            self?.present(detailViewController, animated: true, completion: nil)
+            self?.navigationController?.pushViewController(detailViewController, animated: true)
         })
     }
     

--- a/iOS/AirbnbApp/AirbnbApp/StayList/Controllers/StayListViewController.swift
+++ b/iOS/AirbnbApp/AirbnbApp/StayList/Controllers/StayListViewController.swift
@@ -89,7 +89,7 @@ class StayListViewController: UIViewController {
     @IBAction func mapButtonTouched(_ sender: Any) {
         #warning("동작 확인용 VC")
         let viewController = UIViewController()
-        viewController.modalPresentationStyle = .automatic // .fullScreen
+        viewController.modalPresentationStyle = .automatic // .fullScreen으로 변경할 것
         viewController.view.backgroundColor = .systemTeal
         present(viewController, animated: true)
     }

--- a/iOS/AirbnbApp/AirbnbApp/StayList/Controllers/StayListViewController.swift
+++ b/iOS/AirbnbApp/AirbnbApp/StayList/Controllers/StayListViewController.swift
@@ -3,7 +3,7 @@ import UIKit
 class StayListViewController: UIViewController {
     
     private var searchFieldView: SearchFieldView!
-    private var seperatorView: SeperatorView!
+    private var separatorView: SeparatorView!
     private var searchFilterView: SearchFilterView!
     private var stayListCollectionView: StayListCollectionView!
     private var stayListCollectionViewDataSource: StayListCollectionViewDataSource!
@@ -65,7 +65,7 @@ class StayListViewController: UIViewController {
         view.backgroundColor = .white
 
         searchFieldView = SearchFieldView.loadFromXib()
-        seperatorView = SeperatorView()
+        separatorView = SeparatorView()
         searchFilterView = SearchFilterView.loadFromXib()
         stayListCollectionView = StayListCollectionView()
         mapButtonView = MapButtonView.loadFromXib()
@@ -92,7 +92,7 @@ class StayListViewController: UIViewController {
 extension StayListViewController {
     private func configureLayout() {
         view.addSubviews(searchFieldView,
-                         seperatorView,
+                         separatorView,
                          searchFilterView,
                          stayListCollectionView,
                          mapButtonView,
@@ -109,7 +109,7 @@ extension StayListViewController {
                                                     right: sidePadding + 16),
                                      size: .init(width: 0,
                                                  height: SearchFieldView.height))
-        seperatorView.constraints(topAnchor: searchFieldView.bottomAnchor,
+        separatorView.constraints(topAnchor: searchFieldView.bottomAnchor,
                                   leadingAnchor: view.leadingAnchor,
                                   bottomAnchor: nil,
                                   trailingAnchor: view.trailingAnchor,

--- a/iOS/AirbnbApp/AirbnbApp/StayList/Controllers/StayListViewController.swift
+++ b/iOS/AirbnbApp/AirbnbApp/StayList/Controllers/StayListViewController.swift
@@ -7,6 +7,7 @@ class StayListViewController: UIViewController {
     private var searchFilterView: SearchFilterView!
     private var stayListCollectionView: StayListCollectionView!
     private var stayListCollectionViewDataSource: StayListCollectionViewDataSource!
+    private var stayListCollectionViewDelegate: StayListCollectionViewDelegate!
     private var mapButtonView: MapButtonView!
     private var searchTextFieldDelegate: SearchTextFieldDelegate!
     private var loadingView: LoadingView!
@@ -16,7 +17,7 @@ class StayListViewController: UIViewController {
         
         configureUI()
         configureLayout()
-        configureStayListCollectionViewDataSourceHandler()
+        configureStayListCollectionViewHandlers()
         configureCollectionView()
         configureTextFieldDelegate()
         fetchFakeStayList()
@@ -39,12 +40,17 @@ class StayListViewController: UIViewController {
         }
     }
     
-    private func configureStayListCollectionViewDataSourceHandler() {
+    private func configureStayListCollectionViewHandlers() {
         stayListCollectionViewDataSource = StayListCollectionViewDataSource(changedHandler: { [weak self] (_) in
             DispatchQueue.main.async {
                 self?.stayListCollectionView.reloadData()
                 self?.dismissLoadingView()
             }
+        })
+
+        stayListCollectionViewDelegate = StayListCollectionViewDelegate(handlerWhenSelected: { [weak self] in
+            let detailViewController = StayDetailViewController()
+            self?.present(detailViewController, animated: true, completion: nil)
         })
     }
     
@@ -59,6 +65,9 @@ class StayListViewController: UIViewController {
     
     private func configureCollectionView() {
         stayListCollectionView.dataSource = stayListCollectionViewDataSource
+
+        // FIXME: delegate 지정하면 셀 크기가 이상하게 바뀜
+        stayListCollectionView.delegate = stayListCollectionViewDelegate
     }
     
     private func configureUI() {

--- a/iOS/AirbnbApp/AirbnbApp/StayList/Views/SeparatorView.swift
+++ b/iOS/AirbnbApp/AirbnbApp/StayList/Views/SeparatorView.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-class SeperatorView: UIView {
+class SeparatorView: UIView {
     
     override init(frame: CGRect) {
         super.init(frame: frame)

--- a/iOS/AirbnbApp/AirbnbApp/StayList/Views/StayListCollectionView.swift
+++ b/iOS/AirbnbApp/AirbnbApp/StayList/Views/StayListCollectionView.swift
@@ -13,13 +13,8 @@ class StayListCollectionView: UICollectionView {
     }
     
     private func configure() {
-        configureCollectionViewDelegate()
         configureCell()
         configureUI()
-    }
-    
-    private func configureCollectionViewDelegate() {
-        delegate = self
     }
     
     private func configureCell() {
@@ -30,19 +25,5 @@ class StayListCollectionView: UICollectionView {
     private func configureUI() {
         backgroundColor = .clear
         showsVerticalScrollIndicator = false
-    }
-}
-
-extension StayListCollectionView: UICollectionViewDelegateFlowLayout {	
-    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-        let scrollViewHeight = collectionView.bounds.width * (3 / 5)
-        let verticalSpace: CGFloat = 12.0
-        let stackViewHeight: CGFloat = 100.0
-
-        return CGSize(width: collectionView.bounds.width, height: scrollViewHeight + verticalSpace + stackViewHeight)
-    }
-    
-    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
-        24
     }
 }

--- a/iOS/AirbnbApp/AirbnbApp/TabBar/TabBarController.swift
+++ b/iOS/AirbnbApp/AirbnbApp/TabBar/TabBarController.swift
@@ -2,8 +2,6 @@ import UIKit
 
 class TabBarController: UITabBarController {
     
-    private var navViewController: UINavigationController!
-
     override func viewDidLoad() {
         super.viewDidLoad()
         
@@ -19,10 +17,15 @@ class TabBarController: UITabBarController {
     }
     
     private func configureTabBarControllers() {
-        navViewController = UINavigationController(rootViewController: StayListViewController())
-        viewControllers = [navViewController]
+        viewControllers = [makeRootViewControllerNamedExplore()]
+    }
+
+    private func makeRootViewControllerNamedExplore() -> UIViewController {
+        let navViewController = UINavigationController(rootViewController: StayListViewController())
 
         let item = UITabBarItem(title: "EXPLORE", image: UIImage(systemName: "magnifyingglass"), tag: 0)
         navViewController.tabBarItem = item
+
+        return navViewController
     }
 }

--- a/iOS/AirbnbApp/AirbnbApp/TabBar/TabBarController.swift
+++ b/iOS/AirbnbApp/AirbnbApp/TabBar/TabBarController.swift
@@ -2,7 +2,7 @@ import UIKit
 
 class TabBarController: UITabBarController {
     
-    private var stayListViewController: StayListViewController!
+    private var navViewController: UINavigationController!
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -19,11 +19,10 @@ class TabBarController: UITabBarController {
     }
     
     private func configureTabBarControllers() {
-        stayListViewController = StayListViewController()
-
-        viewControllers = [stayListViewController]
+        navViewController = UINavigationController(rootViewController: StayListViewController())
+        viewControllers = [navViewController]
 
         let item = UITabBarItem(title: "EXPLORE", image: UIImage(systemName: "magnifyingglass"), tag: 0)
-        stayListViewController.tabBarItem = item
+        navViewController.tabBarItem = item
     }
 }


### PR DESCRIPTION
상세 뷰에 대한 기본 구현이에요.
- TabBarController > NavigationController > StayListViewController 구조로 바꿨어요.
- Cell 터치 시 상세뷰로 이동: collectionView의 delegate를 썼는데, 셀 크기가 작아지는 문제가 있네요. 같이 해결해보거나, 다른 방법을 써야 할 것 같아요.
- DetailSectionView: 상세 뷰를 이런 식으로 나누면 될 것 같아요. 테스트용으로 label, button만 두었어요.
- RoundedBorder: 공통 스타일을 이런 식으로 적용하면 어떨까 싶어요. 프로토콜이랑 익스텐션 써서요. 기본값을 어떻게 처리할까가 고민이긴 한데, 메소드의 인자로 우선 구현했어요. 다른 방법으로는 상속받아서 사용하는 방법이 있겠고요. 
- DetailButton: RoundedBorder를 적용한 예시에요. DetailSectionView 안에 있는 버튼이에요.