### PR TITLE
StayList 네트워크 요청 StayCell 및 재사용 초기화

### DIFF
--- a/iOS/AirbnbApp/AirbnbApp.xcodeproj/project.pbxproj
+++ b/iOS/AirbnbApp/AirbnbApp.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 51;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -24,10 +24,12 @@
 		385D8BFC24728ECC009E2E2B /* AirbnbAppTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 385D8BFB24728ECC009E2E2B /* AirbnbAppTests.swift */; };
 		3869C446247BB9AC00A16C6D /* StayList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3869C445247BB9AC00A16C6D /* StayList.swift */; };
 		38863E252478F6AB00D8C75C /* ThumbImagePagingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38863E242478F6AB00D8C75C /* ThumbImagePagingView.swift */; };
+		38AEA756247BF7590058050D /* StayListUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38AEA755247BF7590058050D /* StayListUseCase.swift */; };
 		38BDDCAC24751DED000ACA1C /* ReviewLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38BDDCAB24751DED000ACA1C /* ReviewLabel.swift */; };
 		38BDDCAE2475A36D000ACA1C /* NSMutableAttributedString+append.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38BDDCAD2475A36D000ACA1C /* NSMutableAttributedString+append.swift */; };
 		38BDDCB02475AB21000ACA1C /* LabelWithLeadingImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38BDDCAF2475AB21000ACA1C /* LabelWithLeadingImage.swift */; };
 		38BDDCB22475AD43000ACA1C /* SuperHostLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38BDDCB12475AD43000ACA1C /* SuperHostLabel.swift */; };
+		38DC238B247BDAE200DC3BCC /* NetworkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38DC238A247BDAE200DC3BCC /* NetworkManager.swift */; };
 		38EB9D8F2479A48100236DB4 /* LoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38EB9D8E2479A48100236DB4 /* LoadingView.swift */; };
 		38F1F89224795E0400454668 /* Stay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38F1F89124795E0400454668 /* Stay.swift */; };
 		38F1F89424795F5200454668 /* ViewModelBinding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38F1F89324795F5200454668 /* ViewModelBinding.swift */; };
@@ -78,10 +80,12 @@
 		385D8BFD24728ECC009E2E2B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		3869C445247BB9AC00A16C6D /* StayList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StayList.swift; sourceTree = "<group>"; };
 		38863E242478F6AB00D8C75C /* ThumbImagePagingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThumbImagePagingView.swift; sourceTree = "<group>"; };
+		38AEA755247BF7590058050D /* StayListUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StayListUseCase.swift; sourceTree = "<group>"; };
 		38BDDCAB24751DED000ACA1C /* ReviewLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewLabel.swift; sourceTree = "<group>"; };
 		38BDDCAD2475A36D000ACA1C /* NSMutableAttributedString+append.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSMutableAttributedString+append.swift"; sourceTree = "<group>"; };
 		38BDDCAF2475AB21000ACA1C /* LabelWithLeadingImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabelWithLeadingImage.swift; sourceTree = "<group>"; };
 		38BDDCB12475AD43000ACA1C /* SuperHostLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuperHostLabel.swift; sourceTree = "<group>"; };
+		38DC238A247BDAE200DC3BCC /* NetworkManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkManager.swift; sourceTree = "<group>"; };
 		38EB9D8E2479A48100236DB4 /* LoadingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingView.swift; sourceTree = "<group>"; };
 		38F1F89124795E0400454668 /* Stay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Stay.swift; sourceTree = "<group>"; };
 		38F1F89324795F5200454668 /* ViewModelBinding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModelBinding.swift; sourceTree = "<group>"; };
@@ -132,7 +136,6 @@
 				51291177216A70DD7B1C174C /* Pods-AirbnbAppTests.debug.xcconfig */,
 				F0B4FABD941046CDEC24AF71 /* Pods-AirbnbAppTests.release.xcconfig */,
 			);
-			name = Pods;
 			path = Pods;
 			sourceTree = "<group>";
 		};
@@ -238,6 +241,8 @@
 			children = (
 				8D8FE71B2473CF23008FF0AF /* TabBar */,
 				8D8FE71C2473CF3C008FF0AF /* StayList */,
+				38DC2389247BDAD100DC3BCC /* Network */,
+				38AEA754247BF7400058050D /* UseCases */,
 				384C0E322473D9380051528B /* Extensions */,
 				385D8BE424728EC8009E2E2B /* AppDelegate.swift */,
 				385D8BE624728EC8009E2E2B /* SceneDelegate.swift */,
@@ -264,6 +269,22 @@
 				3859747E2478FF98004A358C /* ThumbImageView.swift */,
 			);
 			path = ThumbImagePaging;
+			sourceTree = "<group>";
+		};
+		38AEA754247BF7400058050D /* UseCases */ = {
+			isa = PBXGroup;
+			children = (
+				38AEA755247BF7590058050D /* StayListUseCase.swift */,
+			);
+			path = UseCases;
+			sourceTree = "<group>";
+		};
+		38DC2389247BDAD100DC3BCC /* Network */ = {
+			isa = PBXGroup;
+			children = (
+				38DC238A247BDAE200DC3BCC /* NetworkManager.swift */,
+			);
+			path = Network;
 			sourceTree = "<group>";
 		};
 		38F1F89024795DED00454668 /* Model */ = {
@@ -485,6 +506,7 @@
 			files = (
 				384C0E342473D9680051528B /* UIView+AutoLayout.swift in Sources */,
 				385D8BE924728EC8009E2E2B /* TabBarController.swift in Sources */,
+				38AEA756247BF7590058050D /* StayListUseCase.swift in Sources */,
 				3839C7B02477D6760039BB19 /* SeperatorView.swift in Sources */,
 				384C0E3C2473F62A0051528B /* StayCell.swift in Sources */,
 				385D8BE524728EC8009E2E2B /* AppDelegate.swift in Sources */,
@@ -497,6 +519,7 @@
 				385D8BE724728EC8009E2E2B /* SceneDelegate.swift in Sources */,
 				38BDDCAE2475A36D000ACA1C /* NSMutableAttributedString+append.swift in Sources */,
 				384C0E392473F50F0051528B /* UIView+addSubviews.swift in Sources */,
+				38DC238B247BDAE200DC3BCC /* NetworkManager.swift in Sources */,
 				38BDDCB22475AD43000ACA1C /* SuperHostLabel.swift in Sources */,
 				381A0304247623F3004EDE84 /* PlaceTypeAndCityLabel.swift in Sources */,
 				3869C446247BB9AC00A16C6D /* StayList.swift in Sources */,

--- a/iOS/AirbnbApp/AirbnbApp/Network/NetworkManager.swift
+++ b/iOS/AirbnbApp/AirbnbApp/Network/NetworkManager.swift
@@ -1,0 +1,21 @@
+import Foundation
+import Alamofire
+
+enum NetworkErrorCase {
+    case NotFound
+    case NetworkError
+}
+
+final class NetworkManager {
+    static func getResource(from URL: URL,
+                               completionHandler: @escaping (Result<Data, AFError>) -> Void) {
+        AF.request(URL).responseData { (responseData) in
+            switch responseData.result {
+            case .success(let data):
+                completionHandler(.success(data))
+            case .failure(let error):
+                completionHandler(.failure(error))
+            }
+        }
+    }
+}

--- a/iOS/AirbnbApp/AirbnbApp/Network/NetworkManager.swift
+++ b/iOS/AirbnbApp/AirbnbApp/Network/NetworkManager.swift
@@ -18,4 +18,17 @@ final class NetworkManager {
             }
         }
     }
+    
+    static func getResource(from urlString: String,
+                           completionHandler: @escaping (Result<Data, AFError>) -> Void) {
+        let url = URL(string: urlString)!
+        AF.request(url).responseData { (response) in
+            switch response.result {
+            case .success(let data):
+                completionHandler(.success(data))
+            case .failure(let error):
+                completionHandler(.failure(error))
+            }
+        }
+    }
 }

--- a/iOS/AirbnbApp/AirbnbApp/StayList/Controllers/StayListViewController.swift
+++ b/iOS/AirbnbApp/AirbnbApp/StayList/Controllers/StayListViewController.swift
@@ -19,23 +19,22 @@ class StayListViewController: UIViewController {
         configureStayListCollectionViewDataSourceHandler()
         configureCollectionView()
         configureTextFieldDelegate()
-        fetchFakeStayList()
+        
+        fetchStayList()
     }
     
-    private func fetchFakeStayList() {
+    private func fetchStayList() {
         loadingView.startLoadingAnimation()
-        var fakeStays = [Stay]()
-        for _ in 0..<19 {
-            let randomDouble = (Double(Int.random(in: 0...99)) * 0.01)
-            let fakeStay = Stay(id: 1, images: ["https://airbnb-codesquad.s3.ap-northeast-2.amazonaws.com/1.jpg",
-            "https://airbnb-codesquad.s3.ap-northeast-2.amazonaws.com/2.jpg",
-            "https://airbnb-codesquad.s3.ap-northeast-2.amazonaws.com/3.jpg"], saved: false, reviewAverage: Double(Int.random(in: 2...4)) + randomDouble, numberOfReviews: Int.random(in: 10...999), hostType: "", placeType: "Entire Apartment", city: "Upper East Side", state: "Korea", title: "해운대/펜트하우스/더탑플로어", price: Int.random(in: 100...9999), latitude: "", longitude: "")
-            fakeStays.append(fakeStay)
-        }
-        
-        Timer.scheduledTimer(withTimeInterval: 2, repeats: false) {
-          (timer) in
-            self.stayListCollectionViewDataSource.configure(with: fakeStays)
+        StayListUseCase.getStayList { (result) in
+            switch result {
+            case .success(let stayList):
+                DispatchQueue.main.async {
+                    self.stayListCollectionViewDataSource.configure(with: stayList)
+                }
+            case .failure(let error):
+                #warning("Handling fetching stay list error")
+                break
+            }
         }
     }
     

--- a/iOS/AirbnbApp/AirbnbApp/StayList/Controllers/StayListViewController.swift
+++ b/iOS/AirbnbApp/AirbnbApp/StayList/Controllers/StayListViewController.swift
@@ -32,10 +32,27 @@ class StayListViewController: UIViewController {
                     self.stayListCollectionViewDataSource.configure(with: stayList)
                 }
             case .failure(let error):
-                #warning("Handling fetching stay list error")
-                break
+                DispatchQueue.main.async {
+                    self.presentAlertController(with: error)
+                }
             }
         }
+    }
+    
+    private func presentAlertController(with error: Error) {
+        let message = error.localizedDescription.components(separatedBy: ": ").last
+        let alertController = UIAlertController(title: "Network Error",
+                                                message: message,
+                                                preferredStyle: .alert)
+        let retryAction = UIAlertAction(title: "Retry", style: .default) { (_) in
+            self.fetchStayList()
+        }
+        let doneAction = UIAlertAction(title: "Done", style: .default) { (_) in
+            self.loadingView.stopLoadingAnimation()
+        }
+        alertController.addAction(retryAction)
+        alertController.addAction(doneAction)
+        present(alertController, animated: true, completion: nil)
     }
     
     private func configureStayListCollectionViewDataSourceHandler() {

--- a/iOS/AirbnbApp/AirbnbApp/StayList/Model/Stay.swift
+++ b/iOS/AirbnbApp/AirbnbApp/StayList/Model/Stay.swift
@@ -12,6 +12,6 @@ struct Stay: Decodable {
     let state: String
     let title: String
     let price: Int
-    let latitude: String
-    let longitude: String
+    let latitude: Double
+    let longitude: Double
 }

--- a/iOS/AirbnbApp/AirbnbApp/StayList/ViewModels/StayListCollectionViewDataSource.swift
+++ b/iOS/AirbnbApp/AirbnbApp/StayList/ViewModels/StayListCollectionViewDataSource.swift
@@ -24,8 +24,25 @@ final class StayListCollectionViewDataSource: NSObject, UICollectionViewDataSour
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: StayCell.reuseIdentifier, for: indexPath) as! StayCell
         let stay = stayList[indexPath]
         cell.update(with: stay)
-        #warning("update images with urls")
+        fetchThumbImages(at: cell, with: stay.images)
+        
         return cell
+    }
+    
+    private func fetchThumbImages(at cell: UICollectionViewCell, with imageUrls: [String]) {
+        let cell = cell as! StayCell
+        imageUrls.enumerated().forEach { (index, imageUrl) in
+            NetworkManager.getResource(from: imageUrl) { (result) in
+                switch result {
+                case .success(let data):
+                    DispatchQueue.main.async {
+                        cell.updateImage(at: index, data: data)
+                    }
+                case .failure(_):
+                    break
+                }
+            }
+        }
     }
 }
 

--- a/iOS/AirbnbApp/AirbnbApp/StayList/Views/StayCell/StayCell.swift
+++ b/iOS/AirbnbApp/AirbnbApp/StayList/Views/StayCell/StayCell.swift
@@ -14,19 +14,24 @@ class StayCell: UICollectionViewCell {
     @IBOutlet weak var priceLabel: PriceLabel!
     
     func update(with stay: Stay) {
-        self.reviewLabel.updateWith(reviewAverage: stay.reviewAverage,
+        reviewLabel.updateWith(reviewAverage: stay.reviewAverage,
                                     numberOfReviews: stay.numberOfReviews)
-        self.placeTypeAndCityLabel.updateWith(type: stay.placeType,
+        placeTypeAndCityLabel.updateWith(type: stay.placeType,
                                               city: stay.city)
-        self.titleLabel.text = stay.title
-        self.priceLabel.updateWith(price: stay.price)
-        self.thumbImagePagingView.configureStackView(numberOfImage: stay.images.count)
-        self.superHostLabel.isHidden = stay.hostType != "super"
+        titleLabel.text = stay.title
+        priceLabel.updateWith(price: stay.price)
+        thumbImagePagingView.configureStackView(numberOfImage: stay.images.count)
+        superHostLabel.isHidden = stay.hostType != "super"
         #warning("update SaveButton status")
     }
     
     func updateImage(at index: Int, data: Data) {
         thumbImagePagingView.updateImage(at: index, data: data)
+    }
+    
+    override func prepareForReuse() {
+        superHostLabel.isHidden = true
+        thumbImagePagingView.prepareForReuse()
     }
     
     @IBAction func saveButtonTapped(_ sender: Any) {

--- a/iOS/AirbnbApp/AirbnbApp/StayList/Views/StayCell/StayCell.swift
+++ b/iOS/AirbnbApp/AirbnbApp/StayList/Views/StayCell/StayCell.swift
@@ -23,7 +23,10 @@ class StayCell: UICollectionViewCell {
         self.thumbImagePagingView.configureStackView(numberOfImage: stay.images.count)
         self.superHostLabel.isHidden = stay.hostType != "super"
         #warning("update SaveButton status")
-        #warning("Fetch thumbnail images")
+    }
+    
+    func updateImage(at index: Int, data: Data) {
+        thumbImagePagingView.updateImage(at: index, data: data)
     }
     
     @IBAction func saveButtonTapped(_ sender: Any) {

--- a/iOS/AirbnbApp/AirbnbApp/StayList/Views/ThumbImagePaging/ThumbImagePagingView.swift
+++ b/iOS/AirbnbApp/AirbnbApp/StayList/Views/ThumbImagePaging/ThumbImagePagingView.swift
@@ -31,6 +31,16 @@ final class ThumbImagePagingView: UIView {
         thumbImageViews[index].image = UIImage(data: data)
     }
     
+    func prepareForReuse() {
+        pageControl.currentPage = 0
+        scrollView.contentOffset.x = 0
+        
+        imageStackView.arrangedSubviews.forEach {
+            imageStackView.removeArrangedSubview($0)
+            $0.removeFromSuperview()
+        }
+    }
+    
     private func configure() {
         configureUI()
         configureScrollViewDelegate()

--- a/iOS/AirbnbApp/AirbnbApp/StayList/Views/ThumbImagePaging/ThumbImagePagingView.swift
+++ b/iOS/AirbnbApp/AirbnbApp/StayList/Views/ThumbImagePaging/ThumbImagePagingView.swift
@@ -26,6 +26,11 @@ final class ThumbImagePagingView: UIView {
         }
     }
     
+    func updateImage(at index: Int, data: Data) {
+        let thumbImageViews = imageStackView.arrangedSubviews as! [ThumbImageView]
+        thumbImageViews[index].image = UIImage(data: data)
+    }
+    
     private func configure() {
         configureUI()
         configureScrollViewDelegate()

--- a/iOS/AirbnbApp/AirbnbApp/StayList/Views/ThumbImagePaging/ThumbImageView.swift
+++ b/iOS/AirbnbApp/AirbnbApp/StayList/Views/ThumbImagePaging/ThumbImageView.swift
@@ -22,7 +22,7 @@ final class ThumbImageView: UIImageView {
     private func configureUI() {
         backgroundColor = UIColor(named: "thumb.image.background")
         translatesAutoresizingMaskIntoConstraints = false
-        contentMode = .scaleAspectFit
+        contentMode = .scaleAspectFill
         clipsToBounds = true
     }
     

--- a/iOS/AirbnbApp/AirbnbApp/UseCases/StayListUseCase.swift
+++ b/iOS/AirbnbApp/AirbnbApp/UseCases/StayListUseCase.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+final class StayListUseCase {
+    static let path: String = "https://551ca9ec-85b7-433b-b292-6fad22509ac8.mock.pstmn.io/main"
+    
+    static func getStayList(completionHandler: @escaping (Result<[Stay], Error>) -> Void) {
+        let url = URL(string: path)!
+        NetworkManager.getResource(from: url) { (result) in
+            switch result {
+            case .success(let data):
+                do {
+                    let decodedData = try JSONDecoder().decode([Stay].self, from: data)
+                    completionHandler(.success(decodedData))
+                } catch {
+                    print(error)
+                    return
+                }
+            case .failure(let error):
+                completionHandler(.failure(error))
+            }
+        }
+    }
+}

--- a/iOS/AirbnbApp/AirbnbApp/UseCases/StayListUseCase.swift
+++ b/iOS/AirbnbApp/AirbnbApp/UseCases/StayListUseCase.swift
@@ -8,13 +8,8 @@ final class StayListUseCase {
         NetworkManager.getResource(from: url) { (result) in
             switch result {
             case .success(let data):
-                do {
-                    let decodedData = try JSONDecoder().decode([Stay].self, from: data)
-                    completionHandler(.success(decodedData))
-                } catch {
-                    print(error)
-                    return
-                }
+                guard let decodedData = try? JSONDecoder().decode([Stay].self, from: data) else { return }
+                completionHandler(.success(decodedData))
             case .failure(let error):
                 completionHandler(.failure(error))
             }


### PR DESCRIPTION
## 구현 화면
<img src="https://user-images.githubusercontent.com/34022757/83000669-9e76e100-a045-11ea-99d5-fe7f957802f6.png" width="400px">

<img src="https://user-images.githubusercontent.com/34022757/83001122-442a5000-a046-11ea-9b00-be14a872d633.png" width="400px">

- StayList 네트워크 요청을 위해 NetworkManager와 UseCase를 구현하였습니다.
- StayList 네트워크 요청 시 오류가 발생하면 AlertController를 통해 에러 핸들링을 할 수 있도록 구현하였습니다. 
- StayCell의 이미지 요청을 구현하였습니다. DataSource에서 처리하지 않으려고 하였는데, 다른 방법이 생각나지 않아서 일단 DataSource에 구현하였습니다.
- StayCell을 재사용 할 때는 고려하여 prepareForReuse를 구현하였습니다.
