### PR TITLE
StayCell TapGestureRecognizer 구현

### DIFF
--- a/iOS/AirbnbApp/AirbnbApp/StayList/Controllers/SearchTextFieldDelegate.swift
+++ b/iOS/AirbnbApp/AirbnbApp/StayList/Controllers/SearchTextFieldDelegate.swift
@@ -1,6 +1,7 @@
 import UIKit
 
-class SearchTextFieldDelegate: NSObject, UITextFieldDelegate {
+final class SearchTextFieldDelegate: NSObject, UITextFieldDelegate {
+    
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
         textField.resignFirstResponder()
 

--- a/iOS/AirbnbApp/AirbnbApp/StayList/Controllers/StayListCollectionViewDelegate.swift
+++ b/iOS/AirbnbApp/AirbnbApp/StayList/Controllers/StayListCollectionViewDelegate.swift
@@ -1,18 +1,7 @@
 import UIKit
 
-class StayListCollectionViewDelegate: NSObject, UICollectionViewDelegate {
-    var handlerWhenSelected: () -> Void
-
-    init(handlerWhenSelected: @escaping () -> Void = {}) {
-        self.handlerWhenSelected = handlerWhenSelected
-    }
-
-    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        handlerWhenSelected()
-    }
-}
-
-extension StayListCollectionViewDelegate: UICollectionViewDelegateFlowLayout {
+final class StayListCollectionViewDelegate: NSObject, UICollectionViewDelegateFlowLayout {
+    
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
         let scrollViewHeight = collectionView.bounds.width * (3 / 5)
         let verticalSpace: CGFloat = 12.0

--- a/iOS/AirbnbApp/AirbnbApp/StayList/Controllers/StayListViewController.swift
+++ b/iOS/AirbnbApp/AirbnbApp/StayList/Controllers/StayListViewController.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-class StayListViewController: UIViewController {
+final class StayListViewController: UIViewController {
     
     private var searchFieldView: SearchFieldView!
     private var separatorView: SeparatorView!
@@ -17,7 +17,6 @@ class StayListViewController: UIViewController {
         
         configureUI()
         configureLayout()
-        configureStayListCollectionViewHandlers()
         configureCollectionView()
         configureTextFieldDelegate()
         
@@ -56,17 +55,6 @@ class StayListViewController: UIViewController {
         present(alertController, animated: true, completion: nil)
     }
     
-    private func configureStayListCollectionViewHandlers() {
-        stayListCollectionViewDataSource = StayListCollectionViewDataSource(changedHandler: { [weak self] (_) in
-            DispatchQueue.main.async {
-                self?.stayListCollectionView.reloadData()
-                self?.dismissLoadingView()
-            }
-        })
-
-        stayListCollectionViewDelegate = StayListCollectionViewDelegate()
-    }
-    
     private func dismissLoadingView() {
         UIView.animate(withDuration: 1, delay: 0, usingSpringWithDamping: 1, initialSpringVelocity: 1, options: .curveEaseOut, animations: {
             self.loadingView.alpha = 0
@@ -76,29 +64,7 @@ class StayListViewController: UIViewController {
         }
     }
     
-    private func configureCollectionView() {
-        stayListCollectionView.dataSource = stayListCollectionViewDataSource
-        stayListCollectionView.delegate = stayListCollectionViewDelegate
-        stayListCollectionView.tapDelegate = self
-    }
-    
-    private func configureUI() {
-        view.backgroundColor = .white
-
-        searchFieldView = SearchFieldView.loadFromXib()
-        separatorView = SeparatorView()
-        searchFilterView = SearchFilterView.loadFromXib()
-        stayListCollectionView = StayListCollectionView()
-        mapButtonView = MapButtonView.loadFromXib()
-        loadingView = LoadingView()
-    }
-
-    private func configureTextFieldDelegate() {
-        searchTextFieldDelegate = SearchTextFieldDelegate()
-        searchFieldView.configureTextFieldDelegate(searchTextFieldDelegate)
-    }
-
-    // MARK: - IBAction
+    // MARK: - IBActions
 
     @IBAction func mapButtonTouched(_ sender: Any) {
         #warning("동작 확인용 VC")
@@ -121,9 +87,50 @@ extension StayListViewController: StayListCollectionViewTapDelegate {
     }
 }
 
-// MARK:- Layout
+extension StayListViewController {
+    private func configureCollectionViewDatasource() {
+        stayListCollectionViewDataSource = StayListCollectionViewDataSource(changedHandler: { [weak self] (_) in
+            DispatchQueue.main.async {
+                self?.stayListCollectionView.reloadData()
+                self?.dismissLoadingView()
+            }
+        })
+    }
+    
+    private func configureCollectionViewDelegate() {
+        stayListCollectionViewDelegate = StayListCollectionViewDelegate()
+    }
+    
+    private func configureCollectionView() {
+        configureCollectionViewDatasource()
+        configureCollectionViewDelegate()
+        
+        stayListCollectionView.dataSource = stayListCollectionViewDataSource
+        stayListCollectionView.delegate = stayListCollectionViewDelegate
+        stayListCollectionView.tapDelegate = self
+    }
+    
+    private func configureTextFieldDelegate() {
+        searchTextFieldDelegate = SearchTextFieldDelegate()
+        searchFieldView.configureTextFieldDelegate(searchTextFieldDelegate)
+    }
+}
+
+// MARK:- UI & Layout
 
 extension StayListViewController {
+    
+    private func configureUI() {
+        view.backgroundColor = .white
+
+        searchFieldView = SearchFieldView.loadFromXib()
+        separatorView = SeparatorView()
+        searchFilterView = SearchFilterView.loadFromXib()
+        stayListCollectionView = StayListCollectionView()
+        mapButtonView = MapButtonView.loadFromXib()
+        loadingView = LoadingView()
+    }
+
     private func configureLayout() {
         view.addSubviews(searchFieldView,
                          separatorView,

--- a/iOS/AirbnbApp/AirbnbApp/StayList/Controllers/StayListViewController.swift
+++ b/iOS/AirbnbApp/AirbnbApp/StayList/Controllers/StayListViewController.swift
@@ -64,10 +64,7 @@ class StayListViewController: UIViewController {
             }
         })
 
-        stayListCollectionViewDelegate = StayListCollectionViewDelegate(handlerWhenSelected: { [weak self] in
-            let detailViewController = StayDetailViewController()
-            self?.navigationController?.pushViewController(detailViewController, animated: true)
-        })
+        stayListCollectionViewDelegate = StayListCollectionViewDelegate()
     }
     
     private func dismissLoadingView() {
@@ -82,6 +79,7 @@ class StayListViewController: UIViewController {
     private func configureCollectionView() {
         stayListCollectionView.dataSource = stayListCollectionViewDataSource
         stayListCollectionView.delegate = stayListCollectionViewDelegate
+        stayListCollectionView.tapDelegate = self
     }
     
     private func configureUI() {
@@ -111,7 +109,17 @@ class StayListViewController: UIViewController {
     }
 }
 
+// MARK:- Delegation Configuration
+
+extension StayListViewController: StayListCollectionViewTapDelegate {
+    func didTapCell(at indexPath: IndexPath) {
+        let detailViewController = StayDetailViewController()
+        self.navigationController?.pushViewController(detailViewController, animated: true)
+    }
+}
+
 // MARK:- Layout
+
 extension StayListViewController {
     private func configureLayout() {
         view.addSubviews(searchFieldView,

--- a/iOS/AirbnbApp/AirbnbApp/StayList/Controllers/StayListViewController.swift
+++ b/iOS/AirbnbApp/AirbnbApp/StayList/Controllers/StayListViewController.swift
@@ -113,8 +113,11 @@ class StayListViewController: UIViewController {
 
 extension StayListViewController: StayListCollectionViewTapDelegate {
     func didTapCell(at indexPath: IndexPath) {
-        let detailViewController = StayDetailViewController()
-        self.navigationController?.pushViewController(detailViewController, animated: true)
+        stayListCollectionViewDataSource.idForCell(at: indexPath) { [weak self] (id) in
+            let detailViewController = StayDetailViewController()
+            #warning("Request detail data")
+            self?.navigationController?.pushViewController(detailViewController, animated: true)
+        }
     }
 }
 

--- a/iOS/AirbnbApp/AirbnbApp/StayList/ViewModels/StayListCollectionViewDataSource.swift
+++ b/iOS/AirbnbApp/AirbnbApp/StayList/ViewModels/StayListCollectionViewDataSource.swift
@@ -20,6 +20,11 @@ final class StayListCollectionViewDataSource: NSObject, UICollectionViewDataSour
         self.stayList = StayList(stays)
     }
     
+    func idForCell(at indexPath: IndexPath, handler: (Int) -> Void) {
+        let stay = stayList[indexPath]
+        handler(stay.id)
+    }
+    
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: StayCell.reuseIdentifier, for: indexPath) as! StayCell
         let stay = stayList[indexPath]

--- a/iOS/AirbnbApp/AirbnbApp/StayList/Views/LoadingView.swift
+++ b/iOS/AirbnbApp/AirbnbApp/StayList/Views/LoadingView.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-class LoadingView: UIView {
+final class LoadingView: UIView {
     
     private var activityIndicatorView: UIActivityIndicatorView!
     

--- a/iOS/AirbnbApp/AirbnbApp/StayList/Views/MapButton/MapButtonView.swift
+++ b/iOS/AirbnbApp/AirbnbApp/StayList/Views/MapButton/MapButtonView.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-class MapButtonView: UIView, ViewFromXib {
+final class MapButtonView: UIView, ViewFromXib {
     
     static let xibName = String(describing: MapButtonView.self)
     static let width: CGFloat = 80

--- a/iOS/AirbnbApp/AirbnbApp/StayList/Views/SearchField/SearchFieldView.swift
+++ b/iOS/AirbnbApp/AirbnbApp/StayList/Views/SearchField/SearchFieldView.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-class SearchFieldView: UIView, ViewFromXib {
+final class SearchFieldView: UIView, ViewFromXib {
 
     static let xibName = String(describing: SearchFieldView.self)
     static let height: CGFloat = 40.0

--- a/iOS/AirbnbApp/AirbnbApp/StayList/Views/SearchFilter/SearchFilterView.swift
+++ b/iOS/AirbnbApp/AirbnbApp/StayList/Views/SearchFilter/SearchFilterView.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-class SearchFilterView: UIView, ViewFromXib {
+final class SearchFilterView: UIView, ViewFromXib {
     
     static let xibName = String(describing: SearchFilterView.self)
     static let height: CGFloat = 40

--- a/iOS/AirbnbApp/AirbnbApp/StayList/Views/StayCell/PlaceTypeAndCityLabel.swift
+++ b/iOS/AirbnbApp/AirbnbApp/StayList/Views/StayCell/PlaceTypeAndCityLabel.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-class PlaceTypeAndCityLabel: UILabel {
+final class PlaceTypeAndCityLabel: UILabel {
 
     func updateWith(type: String, city: String) {
         text = "\(type) ・ \(city)"

--- a/iOS/AirbnbApp/AirbnbApp/StayList/Views/StayCell/PriceLabel.swift
+++ b/iOS/AirbnbApp/AirbnbApp/StayList/Views/StayCell/PriceLabel.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-class PriceLabel: UILabel {
+final class PriceLabel: UILabel {
 
     func updateWith(price: Int) {
         let attributedText = NSMutableAttributedString(string: "")

--- a/iOS/AirbnbApp/AirbnbApp/StayList/Views/StayCell/ReviewLabel.swift
+++ b/iOS/AirbnbApp/AirbnbApp/StayList/Views/StayCell/ReviewLabel.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-class ReviewLabel: UILabel, LabelWithLeadingImage {
+final class ReviewLabel: UILabel, LabelWithLeadingImage {
     
     internal var leadingImage: UIImage? = UIImage(named: "review.star")
     internal var leadingImageTintColor: UIColor! = UIColor(named: "stay.tintcolor")

--- a/iOS/AirbnbApp/AirbnbApp/StayList/Views/StayCell/StayCell.swift
+++ b/iOS/AirbnbApp/AirbnbApp/StayList/Views/StayCell/StayCell.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-class StayCell: UICollectionViewCell {
+final class StayCell: UICollectionViewCell {
     
     static let nibName: String = String(describing: StayCell.self)
     static let reuseIdentifier: String = "StayCell"

--- a/iOS/AirbnbApp/AirbnbApp/StayList/Views/StayCell/SuperHostLabel.swift
+++ b/iOS/AirbnbApp/AirbnbApp/StayList/Views/StayCell/SuperHostLabel.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-class SuperHostLabel: UILabel, LabelWithLeadingImage {
+final class SuperHostLabel: UILabel, LabelWithLeadingImage {
     
     internal var leadingImage: UIImage? = UIImage(named: "host.super")
     internal var leadingImageTintColor: UIColor! = UIColor(named: "stay.tintcolor")

--- a/iOS/AirbnbApp/AirbnbApp/StayList/Views/StayListCollectionView.swift
+++ b/iOS/AirbnbApp/AirbnbApp/StayList/Views/StayListCollectionView.swift
@@ -1,6 +1,13 @@
 import UIKit
 
-class StayListCollectionView: UICollectionView {
+protocol StayListCollectionViewTapDelegate: class {
+    func didTapCell(at indexPath: IndexPath)
+}
+
+final class StayListCollectionView: UICollectionView {
+    
+    private var tapGestureRecognizer: UITapGestureRecognizer!
+    weak var tapDelegate: StayListCollectionViewTapDelegate?
 
     override init(frame: CGRect, collectionViewLayout layout: UICollectionViewLayout) {
         super.init(frame: frame, collectionViewLayout: UICollectionViewFlowLayout())
@@ -10,6 +17,10 @@ class StayListCollectionView: UICollectionView {
     required init?(coder: NSCoder) {
         super.init(coder: coder)
         configure()
+    }
+    
+    deinit {
+        removeGestureRecognizer(tapGestureRecognizer)
     }
     
     private func configure() {
@@ -25,5 +36,15 @@ class StayListCollectionView: UICollectionView {
     private func configureUI() {
         backgroundColor = .clear
         showsVerticalScrollIndicator = false
+        
+        tapGestureRecognizer = UITapGestureRecognizer(target: self,
+                                                      action: #selector(didTapCollectionView))
+        addGestureRecognizer(tapGestureRecognizer)
+    }
+    
+    @objc func didTapCollectionView(recognizer: UITapGestureRecognizer) {
+        let location = recognizer.location(in: self)
+        guard let indexPath = self.indexPathForItem(at: location) else { return }
+        tapDelegate?.didTapCell(at: indexPath)
     }
 }


### PR DESCRIPTION
## TapGestureRecognizer
UITapGestureRecognizer을 사용하여 스크롤 뷰 위에도 tap을 처리할 수 있도록 구현하였습니다.
받은 tap의 location의 포인트를 계산하여 해당 cell의 indexPath를 계산 하였습니다.

## CollectionViewTapDelegate
StayListCollectionViewTapDelegate 프로토콜을 만들어서 StayListVC가 채택하여 CollectionView의 action을 위임하여 처리할 수 있도록 구현하였습니다.
tap selector에서 indexPath와 함께 tapDelegate의 didTapCell() 메소드에 전달하도록 하였습니다.

## DataSource의 id 가져오기
StayListVC에서 DataSource의 id를 알기 위해서 DataSource에 클로저를 사용하여 handler parameter를 통해서 id를 전달하도록 구현하였습니다.

## 리팩토링
StayList 관련 final class로 변경해주었고, 코드 위치를 extension과 MARK로 정리하였습니다.